### PR TITLE
refactor: 내가 작성한 게시글 리스트 가져오기 기능 신고글/제보글 api 분리

### DIFF
--- a/src/main/java/com/patrol/api/member/member/controller/ApiV2MemberController.java
+++ b/src/main/java/com/patrol/api/member/member/controller/ApiV2MemberController.java
@@ -15,6 +15,7 @@ import com.patrol.global.webMvc.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -89,9 +90,19 @@ public class ApiV2MemberController {
         return GlobalResponse.success();
     }
 
-    // 마이페이지 > 작성글 리스트 불러오기
-    @GetMapping("/posts")
-    public GlobalResponse<Page<MyPostsResponse>> myPosts(@LoginUser Member member, Pageable pageable) {
-        return GlobalResponse.success(v2MemberService.myPosts(member, pageable));
+    // 마이페이지 나의 신고글 리스트 불러오기
+    @GetMapping("/posts/reports")
+    public GlobalResponse<Page<MyPostsResponse>> myReportPosts(
+            @LoginUser Member member,
+            @PageableDefault(size = 5) Pageable pageable) {
+        return GlobalResponse.success(v2MemberService.myReportPosts(member, pageable));
+    }
+    
+    // 마이페이지 나의 제보글 리스트 불러오기
+    @GetMapping("/posts/witnesses")
+    public GlobalResponse<Page<MyPostsResponse>> myWitnessPosts(
+            @LoginUser Member member,
+            @PageableDefault(size = 5) Pageable pageable) {
+        return GlobalResponse.success(v2MemberService.myWitnessPosts(member, pageable));
     }
 }

--- a/src/main/java/com/patrol/domain/lostFoundPost/repository/LostFoundPostRepository.java
+++ b/src/main/java/com/patrol/domain/lostFoundPost/repository/LostFoundPostRepository.java
@@ -28,4 +28,7 @@ public interface LostFoundPostRepository extends JpaRepository<LostFoundPost, Lo
 
     // 현재 로그인된 멤버의 모든 게시글 페이징 처리 후 가져오기
     Page<LostFoundPost> findByAuthorId(Long authorId, Pageable pageable);
+
+    // 게시글 상태에 따라 신고글/제보글 가져오기
+    Page<LostFoundPost> findByAuthorIdAndStatusIn(Long authorId, List<PostStatus> statuses, Pageable pageable);
 }

--- a/src/main/java/com/patrol/domain/lostFoundPost/service/LostFoundPostService.java
+++ b/src/main/java/com/patrol/domain/lostFoundPost/service/LostFoundPostService.java
@@ -274,4 +274,38 @@ public class LostFoundPostService {
                 post.getCreatedAt().toString()
         ));
     }
+    // 마이페이지 나의 신고글 리스트 불러오기
+    @Transactional
+    public Page<MyPostsResponse> myReportPosts(Member member, Pageable pageable) {
+        Page<LostFoundPost> reportPosts = lostFoundPostRepository.findByAuthorIdAndStatusIn(
+                member.getId(),
+                List.of(PostStatus.FINDING, PostStatus.FOUND),
+                pageable
+        );
+
+        return reportPosts.map(post -> new MyPostsResponse(
+                post.getContent(),
+                post.getStatus(),
+                post.getFindTime(),
+                post.getLostTime(),
+                post.getCreatedAt().toString()
+        ));
+    }
+    // 마이페이지 나의 제보글 리스트 불러오기
+    @Transactional
+    public Page<MyPostsResponse> myWitnessPosts(Member member, Pageable pageable) {
+        Page<LostFoundPost> witnessPosts = lostFoundPostRepository.findByAuthorIdAndStatusIn(
+                member.getId(),
+                List.of(PostStatus.SHELTER, PostStatus.FOSTERING, PostStatus.SIGHTED),
+                pageable
+        );
+
+        return witnessPosts.map(post -> new MyPostsResponse(
+                post.getContent(),
+                post.getStatus(),
+                post.getFindTime(),
+                post.getLostTime(),
+                post.getCreatedAt().toString()
+        ));
+    }
 }

--- a/src/main/java/com/patrol/domain/member/member/service/V2MemberService.java
+++ b/src/main/java/com/patrol/domain/member/member/service/V2MemberService.java
@@ -151,9 +151,14 @@ public class V2MemberService {
         return v2MemberRepository.findByEmail(email).isPresent();
     }
 
-    // 마이페이지 > 작성글 리스트 불러오기
+    // 마이페이지 나의 신고글 리스트 불러오기
     @Transactional
-    public Page<MyPostsResponse> myPosts(Member member, Pageable pageable) {
-        return lostFoundPostService.myPosts(member, pageable);
+    public Page<MyPostsResponse> myReportPosts(Member member, Pageable pageable) {
+        return lostFoundPostService.myReportPosts(member, pageable);
+    }
+    // 마이페이지 나의 제보글 리스트 불러오기
+    @Transactional
+    public Page<MyPostsResponse> myWitnessPosts(Member member, Pageable pageable) {
+        return lostFoundPostService.myWitnessPosts(member, pageable);
     }
 }


### PR DESCRIPTION
## 변경사항
- 클라이언트단에서 게시글을 효율적으로 관리하기 위해 기존 내가 작성한 모든 게시글 가져오는 api 삭제 후
신고글, 제보글 가져오기 api를 분리