### PR TITLE
feat: 파일 확장자 검증(jpeg, png, gif, jpg), 파일 크기 검증(5MB 제한) 로직 추가

### DIFF
--- a/src/main/java/com/patrol/global/error/ErrorCode.java
+++ b/src/main/java/com/patrol/global/error/ErrorCode.java
@@ -35,6 +35,10 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST,"사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.FORBIDDEN, "이미 사용중인 이메일 입니다."),
 
+    // File
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 5MB를 넘을 수 없습니다."),
+
     // Auth
     EMAIL_NOT_FOUND(HttpStatus.FORBIDDEN, "등록되지 않은 이메일 입니다."),
     VERIFICATION_NOT_FOUND(HttpStatus.FORBIDDEN, "유효하지 않은 접근입니다."),

--- a/src/main/java/com/patrol/global/storage/FileStorageHandler.java
+++ b/src/main/java/com/patrol/global/storage/FileStorageHandler.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 
@@ -35,6 +37,18 @@ public class FileStorageHandler {
 //                }
 //                return null;
 //            }
+            // 파일 확장자 검증
+            String contentType = request.getFile().getContentType();
+            List<String> allowedTypes = Arrays.asList("image/jpeg", "image/png", "image/gif", "image/jpg");
+            if (!allowedTypes.contains(contentType)) {
+                throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+            }
+
+            // 파일 크기 검증 (5MB 제한)
+            long maxSize = 5 * 1024 * 1024; // 5MB
+            if (request.getFile().getSize() > maxSize) {
+                throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+            }
 
             // 새 파일 업로드
             String filename = UUID.randomUUID().toString();


### PR DESCRIPTION
## 변경사항
#### 파일 업로드 시 이미지 파일만 올라가도록 검증 추가
- 파일 형식 jpeg, png, gif, jpg만 허용
- 업로드 용량 제한 5MB
